### PR TITLE
Runtime Configuration

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/runtime-configuration.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/runtime-configuration.mdx
@@ -1,43 +1,43 @@
 ---
-title: Runtime Config
-description: Add client and server runtime configuration to your Next.js app.
+title: 런타임 구성
+description: Next.js 앱에 클라이언트 및 서버 런타임 구성을 추가하세요.
 ---
 
-> **Good to know**: This feature is considered legacy and does not work with [Automatic Static Optimization](/docs/pages/building-your-application/rendering/automatic-static-optimization), [Output File Tracing](/docs/pages/api-reference/next-config-js/output#automatically-copying-traced-files), or [React Server Components](/docs/getting-started/react-essentials#server-components). Please use [environment variables](/docs/pages/building-your-application/configuring/environment-variables) instead to avoid initialization overhead.
+> **참고**: 이 기능은 레거시로 간주하며 [자동 정적 최적화](/docs/pages/building-your-application/rendering/automatic-static-optimization), [출력 파일 추적](/docs/pages/api-reference/next-config-js/output#automatically-copying-traced-files), 또는 [React 서버 구성 요소](/docs/getting-started/react-essentials#server-components)와 함께 작동하지 않습니다. 초기화 오버헤드를 피하려면 대신 [환경 변수](/docs/pages/building-your-application/configuring/environment-variables)를 사용하세요.
 
-To add runtime configuration to your app, open `next.config.js` and add the `publicRuntimeConfig` and `serverRuntimeConfig` configs:
+앱에 런타임 구성을 추가하려면 `next.config.js` 파일을 열고 `publicRuntimeConfig` 및 `serverRuntimeConfig` 설정을 추가하세요.
 
 ```js filename="next.config.js"
 module.exports = {
   serverRuntimeConfig: {
-    // Will only be available on the server side
+    // 서버 측(server side)에서만 사용할 수 있습니다.
     mySecret: 'secret',
-    secondSecret: process.env.SECOND_SECRET, // Pass through env variables
+    secondSecret: process.env.SECOND_SECRET, // 환경 변수를 통해 전달
   },
   publicRuntimeConfig: {
-    // Will be available on both server and client
+    // 서버 및 클라이언트 양쪽에서 사용할 수 있습니다.
     staticFolder: '/static',
   },
 }
 ```
 
-Place any server-only runtime config under `serverRuntimeConfig`.
+서버 전용 런타임 구성은 `serverRuntimeConfig` 아래에 배치하세요.
 
-Anything accessible to both client and server-side code should be under `publicRuntimeConfig`.
+클라이언트 및 서버 측 코드에서 접근할 수 있는 모든 것은 `publicRuntimeConfig` 아래에 배치해야 합니다.
 
-> A page that relies on `publicRuntimeConfig` **must** use `getInitialProps` or `getServerSideProps` or your application must have a [Custom App](/docs/pages/building-your-application/routing/custom-app) with `getInitialProps` to opt-out of [Automatic Static Optimization](/docs/pages/building-your-application/rendering/automatic-static-optimization). Runtime configuration won't be available to any page (or component in a page) without being server-side rendered.
+> `publicRuntimeConfig`에 의존하는 페이지는 **반드시** `getInitialProps` 또는 `getServerSideProps`를 사용하거나 [사용자 지정 앱](/docs/pages/building-your-application/routing/custom-app)에 [자동 정적 최적화](/docs/pages/building-your-application/rendering/automatic-static-optimization)를 해제하는 `getInitialProps`가 있어야 합니다. 런타임 구성은 서버 측에서 렌더링 되지 않은 페이지(또는 페이지 내 구성 요소)에서 사용할 수 없습니다.
 
-To get access to the runtime configs in your app use `next/config`, like so:
+앱에서 런타임 구성에 접근하려면 `next/config`를 사용하세요.
 
 ```jsx
 import getConfig from 'next/config'
 import Image from 'next/image'
 
-// Only holds serverRuntimeConfig and publicRuntimeConfig
+// serverRuntimeConfig 및 publicRuntimeConfig만 보유합니다.
 const { serverRuntimeConfig, publicRuntimeConfig } = getConfig()
-// Will only be available on the server-side
+// 서버 측에서만 사용할 수 있습니다.
 console.log(serverRuntimeConfig.mySecret)
-// Will be available on both server-side and client-side
+// 서버 측 및 클라이언트 측에서 사용할 수 있습니다.
 console.log(publicRuntimeConfig.staticFolder)
 
 function MyImage() {


### PR DESCRIPTION
This commit adds the initial Korean translation draft for the Runtime Configuration document, which includes the following:
- Translation of titles and descriptions
- Translation of the content

Related to issue #290.

## 기여자용

### 문서 개선

- PR을 열기 전에 `pnpm prettier-fix`를 실행하여 서식 문제를 해결합니다. - 문서 기여 가이드를 읽고 문서 지침을 따르는지 확인하세요: https://github.com/Nextjs-kr/Nextjs.ko/blob/main/packages/next/README.md

<!--

기본적인 지침은 React Docs 한국어 번역작업 가이드를 따릅니다.
https://github.com/reactjs/ko.react.dev

-->

## Progress

- [x] `pnpm prettier-fix`
- [x] 번역 초안 작성 (Draft translation)
- [x] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [x] [모범사례 확인 (Check best practices)](https://github.com/Nextjs-kr/Nextjs.kr/wiki/Best-practices-for-translation)
- [x] [용어 확인 (Check the term)](https://github.com/Nextjs-kr/Nextjs.kr/wiki/Translate-Glossary)
- [x] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)

[//]: # '-->'
